### PR TITLE
Minor tweaks

### DIFF
--- a/hklifxd.go
+++ b/hklifxd.go
@@ -213,6 +213,9 @@ func GetHKLight(light common.Light) *HKLight {
 		if (brightness > 0 && !currentPower) {
 			log.Printf("[INFO] Color changed for %s, turning on power.", label)
 			light.SetPowerDuration(true, transitionDuration)
+		} else if (brightness == 0 && currentPower) {
+			log.Printf("[INFO] Color changed for %s, but brightness = 0 turning off power.", label)
+			light.SetPower(false)
 		}
 	}
 

--- a/hklifxd.go
+++ b/hklifxd.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pdf/golifx"
 	"github.com/pdf/golifx/common"
 	"github.com/pdf/golifx/protocol"
+	"github.com/pdf/golifx/protocol/v2/shared"
 )
 
 const (
@@ -100,6 +101,8 @@ func NewDevice(device common.Device) {
 				hkLight.light.SetHue(hue)
 				hkLight.light.SetSaturation(saturation)
 				hkLight.light.SetBrightness(int(brightness))
+			case shared.EventBroadcastSent:
+				// Suppress event
 
 			default:
 				log.Printf("[INFO] Unknown Device Event: %T", event)

--- a/hklifxd.go
+++ b/hklifxd.go
@@ -180,6 +180,8 @@ func GetHKLight(light common.Light) *HKLight {
 	})
 
 	updateColor := func(light common.Light) {
+		currentPower, _ := light.GetPower()
+
 		// HAP: [0...360]
 		// LIFX: [0...MAX_UINT16]
 		hue := lightBulb.GetHue()
@@ -207,6 +209,11 @@ func GetHKLight(light common.Light) *HKLight {
 		}
 
 		light.SetColor(color, transitionDuration)
+
+		if (brightness > 0 && !currentPower) {
+			log.Printf("[INFO] Color changed for %s, turning on power.", label)
+			light.SetPowerDuration(true, transitionDuration)
+		}
 	}
 
 	lightBulb.OnHueChanged(func(value float64) {


### PR DESCRIPTION
This PR contains three tweaks:
- it suppresses logging for some events to clean up the verbose output;
- It powers up bulbs when their color changes and the brightness is non-zero;
- It powers down bulbs when their color changes and the brightness is zero.
