### PR TITLE
Enhanced the README with the necessary go get cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ After pairing the light bulbs with HomeKit using any iOS HomeKit app (e.g. [Home
         # Clone project
         git clone https://github.com/brutella/hklifx && cd hklifx
         
+        # Fetch hklifxd go dependencies
+        go get
 4. Run
 
         go run hklifxd.go -pin 00102003 -v


### PR DESCRIPTION
Without running go get before running hklifxd I received:

pi@raspberry:~/hklifx_workspace/src/hklifx $ go run hklifxd.go -pin 13371337 -v
vendor/github.com/brutella/hc/crypto/chacha20poly1305/chacha20_poly1305.go:6:2: cannot find package "github.com/aead/chacha20" in any of:
        /home/pi/hklifx_workspace/src/hklifx/vendor/github.com/brutella/hc/vendor/github.com/aead/chacha20 (vendor tree)
        /home/pi/hklifx_workspace/src/hklifx/vendor/github.com/aead/chacha20
        /usr/local/go/src/github.com/aead/chacha20 (from $GOROOT)
        /home/pi/hklifx_workspace/src/github.com/aead/chacha20 (from $GOPATH)
vendor/github.com/pdf/golifx/protocol/v2/packet/packet.go:15:2: cannot find package "github.com/lunixbochs/struc" in any of:
        /home/pi/hklifx_workspace/src/hklifx/vendor/github.com/lunixbochs/struc (vendor tree)
        /usr/local/go/src/github.com/lunixbochs/struc (from $GOROOT)
        /home/pi/hklifx_workspace/src/github.com/lunixbochs/struc (from $GOPATH)
vendor/github.com/brutella/hc/vendor/github.com/oleksandr/bonjour/client.go:10:2: cannot find package "github.com/miekg/dns" in any of:
        /home/pi/hklifx_workspace/src/hklifx/vendor/github.com/brutella/hc/vendor/github.com/miekg/dns (vendor tree)
        /home/pi/hklifx_workspace/src/hklifx/vendor/github.com/miekg/dns
        /usr/local/go/src/github.com/miekg/dns (from $GOROOT)
        /home/pi/hklifx_workspace/src/github.com/miekg/dns (from $GOPATH)
vendor/github.com/pdf/golifx/common/subscription.go:7:2: cannot find package "github.com/satori/go.uuid" in any of:
        /home/pi/hklifx_workspace/src/hklifx/vendor/github.com/satori/go.uuid (vendor tree)
        /usr/local/go/src/github.com/satori/go.uuid (from $GOROOT)
        /home/pi/hklifx_workspace/src/github.com/satori/go.uuid (from $GOPATH)
vendor/github.com/brutella/hc/crypto/curve25519/curve25519.go:5:2: cannot find package "golang.org/x/crypto/curve25519" in any of:
        /home/pi/hklifx_workspace/src/hklifx/vendor/github.com/brutella/hc/vendor/golang.org/x/crypto/curve25519 (vendor tree)
        /home/pi/hklifx_workspace/src/hklifx/vendor/golang.org/x/crypto/curve25519
        /usr/local/go/src/golang.org/x/crypto/curve25519 (from $GOROOT)
        /home/pi/hklifx_workspace/src/golang.org/x/crypto/curve25519 (from $GOPATH)
vendor/github.com/brutella/hc/crypto/hkdf/hkdf.go:5:2: cannot find package "golang.org/x/crypto/hkdf" in any of:
        /home/pi/hklifx_workspace/src/hklifx/vendor/github.com/brutella/hc/vendor/golang.org/x/crypto/hkdf (vendor tree)
        /home/pi/hklifx_workspace/src/hklifx/vendor/golang.org/x/crypto/hkdf
        /usr/local/go/src/golang.org/x/crypto/hkdf (from $GOROOT)
        /home/pi/hklifx_workspace/src/golang.org/x/crypto/hkdf (from $GOPATH)
vendor/github.com/brutella/hc/vendor/github.com/oleksandr/bonjour/client.go:11:2: cannot find package "golang.org/x/net/ipv4" in any of:
        /home/pi/hklifx_workspace/src/hklifx/vendor/github.com/brutella/hc/vendor/golang.org/x/net/ipv4 (vendor tree)
        /home/pi/hklifx_workspace/src/hklifx/vendor/golang.org/x/net/ipv4
        /usr/local/go/src/golang.org/x/net/ipv4 (from $GOROOT)
        /home/pi/hklifx_workspace/src/golang.org/x/net/ipv4 (from $GOPATH)
vendor/github.com/brutella/hc/vendor/github.com/oleksandr/bonjour/client.go:12:2: cannot find package "golang.org/x/net/ipv6" in any of:
        /home/pi/hklifx_workspace/src/hklifx/vendor/github.com/brutella/hc/vendor/golang.org/x/net/ipv6 (vendor tree)
        /home/pi/hklifx_workspace/src/hklifx/vendor/golang.org/x/net/ipv6
        /usr/local/go/src/golang.org/x/net/ipv6 (from $GOROOT)
        /home/pi/hklifx_workspace/src/golang.org/x/net/ipv6 (from $GOPATH)